### PR TITLE
Remove ruby & python examples

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -3,8 +3,6 @@ title: SalesforceIQ - API Documentation
 
 language_tabs:
   - shell
-  - ruby
-  - python
 
 <!-- toc_footers: -->
   <!-- - <a href='#'>Sign Up for a Developer Key</a> -->


### PR DESCRIPTION
Removing ruby & python examples until we're ready to publish them.